### PR TITLE
barcode API v1

### DIFF
--- a/barcode/__init__.py
+++ b/barcode/__init__.py
@@ -3,6 +3,7 @@ from barcode._version import __version__
 from uber.reports import *
 from barcode import *
 from barcode.barcode_utils import generate_barcode_from_badge_num, get_badge_num_from_barcode
+from barcode.barcode_api import *
 
 config = parse_config(__file__)
 mount_site_sections(config['module_root'])

--- a/barcode/barcode_api.py
+++ b/barcode/barcode_api.py
@@ -1,0 +1,30 @@
+from uber.api import fields as attendee_fields
+from barcode import *
+from barcode.barcode_utils import get_badge_num_from_barcode
+
+
+class BarcodeLookup:
+    def lookup_attendee_from_barcode(self, barcode_value):
+        with Session() as session:
+            badge_num = -1
+            try:
+                result = get_badge_num_from_barcode(barcode_value)
+                badge_num = result['badge_num']
+            except Exception as e:
+                return {'error': 'Couldn\'t look up barcode value: ' + str(e)}
+
+            # note: a descrypted barcode can yield to a valid badge#, but an attendee may not have that badge#
+
+            attendee = session.query(Attendee).filter_by(badge_num=badge_num).first()
+            return attendee.to_dict(attendee_fields) if attendee else {'error': 'Valid barcode, but no attendee found with Badge #{}'.format(badge_num)}
+
+    def lookup_badge_number_from_barcode(self, barcode_value):
+        with Session() as session:
+            try:
+                result = get_badge_num_from_barcode(barcode_value)
+                return {'badge_num': result['badge_num']}
+            except Exception as e:
+                return {'error': 'Couldn\'t look up barcode value: ' + str(e)}
+
+
+services.register(BarcodeLookup(), 'barcode')

--- a/barcode/barcode_utils.py
+++ b/barcode/barcode_utils.py
@@ -141,8 +141,7 @@ def verify_barcode_is_valid_code128_charset(str):
 
 def assert_is_valid_rams_barcode(barcode):
     if not verify_is_valid_rams_barcode(barcode):
-        raise ValueError("barcode validation error: this barcode contains a character that " +
-                         "is not valid in a RAMS barcode: '" + barcode + "'")
+        raise ValueError("barcode validation error: invalid format for RAMS barcode: '" + barcode + "'")
 
 
 def _barcode_raw_encrypt(value, key):


### PR DESCRIPTION
Barcode API.  Basically mimics the Attendee API except it takes a barcode as an argument.

```lookup_attendee_from_barcode()``` returns the attendee information associated with this barcode, if the following conditions are met:
- this is a valid barcode for this event
- attendee is either: 
  - checked in
  - has a pre-assigned badge# (i.e. staff badge)


```lookup_badge_number_from_barcode``` just returns the badge# of this barcode, if the following conditions are met:
- this is a valid barcode for this event

--------

On any kind of error, check the resulting JSON for 'error'.

# Python examples

```
from pprint import pprint
from rpctools.jsonrpc import ServerProxy

service = ServerProxy('http://localhost:8282/jsonrpc')

barcode = "XXXXXX"
pprint(service.barcode.lookup_attendee_from_barcode(barcode_value=barcode))
```

example good output:
```
{'_model': 'Attendee',
 'assigned_depts_labels': [],
 'badge_status_label': 'New',
 'badge_type_label': 'Staff',
 'cellphone': '',
 'checked_in': None,
 'ec_phone': '',
 'email': 'magfest@example.com',
 'first_name': 'Test',
 'food_restrictions': None,
 'full_name': 'Test Developer',
 'id': '91321b09-5dff-4fde-bcd6-12d950108740',
 'is_dept_head': False,
 'last_name': 'Developer',
 'ribbon_label': 'no ribbon',
 'shifts': [],
 'staffing': True,
 'weighted_hours': 0.0,
 'worked_hours': 0.0,
 'zip_code': ''}
```

example error output:
```
{'error': "Couldn't look up barcode value: barcode validation error: invalid "
          "format for RAMS barcode: 'XXXXXX'"}
```

# example 2 - badge lookup

```
pprint(service.barcode.lookup_badge_number_from_barcode(barcode_value="XXXXXX"))
```

result:
```
{'badge_num': 1}
```