### PR TITLE
add prefix character to barcodes

### DIFF
--- a/barcode/__init__.py
+++ b/barcode/__init__.py
@@ -5,6 +5,9 @@ from barcode.barcode_utils import generate_barcode_from_badge_num, get_badge_num
 from barcode.barcode_api import *
 
 config = parse_config(__file__)
+
+c.BARCODE_PREFIX_CHAR = config['barcode_prefix_char']
+
 mount_site_sections(config['module_root'])
 static_overrides(join(config['module_root'], 'static'))
 template_overrides(join(config['module_root'], 'templates'))

--- a/barcode/configspec.ini
+++ b/barcode/configspec.ini
@@ -1,3 +1,7 @@
+# a 1-character prefix appended to any barcode (to make it easy to identify it as a barcode)
+# try to pick something that's not base64 related, i.e. not A-Z,a-z,0-9,+,/ and not an equals sign
+barcode_prefix_char = string(default="~")
+
 [secret]
 
 # a secret 10-digit key (KEEP THIS SAFE, SHARE WITH NO-ONE) used to encrypt/decrypt barcodes

--- a/barcode/tests/__init__.py
+++ b/barcode/tests/__init__.py
@@ -22,7 +22,7 @@ def test_encrypt_decrypt(cfg):
     badge_num = 3
     encrypted = generate_barcode_from_badge_num(badge_num=badge_num)
 
-    assert len(encrypted) == 6
+    assert len(encrypted) == 7
     decrypted = get_badge_num_from_barcode(barcode_num=encrypted)
 
     assert decrypted['badge_num'] == badge_num
@@ -57,13 +57,28 @@ def test_dontfail_wrong_event_id(cfg):
     assert decrytped['event_id'] == config['secret']['barcode_event_id']
 
 
-def test_barcode_character_validations(cfg):
+def test_valid_barcode_character_validations(cfg):
     # some valid barcodes
     for s in ["jhgsd+", "ABMN45", "asfnb/", "912765", "++//00"]:
-        assert_is_valid_rams_barcode(s)
 
-    # some invalid barcodes
-    for s in ["^^^^^^", "(}(*&4", "---2hg", "{}{<>?", "      ", "ABCDEFGH", "abcdefgh", "1234567"]:
+        # test to make sure it DOES work with prefix
+        assert_is_valid_rams_barcode(c.BARCODE_PREFIX_CHAR + s)
+
+        # test to make sure it DOES NOT work without prefix
         with pytest.raises(ValueError) as ex:
             assert_is_valid_rams_barcode(s)
+        assert 'barcode validation error' in str(ex.value)
+
+
+def test_invalid_barcode_character_validations(cfg):
+    # some invalid barcodes
+    for s in ["^^^^^^", "(}(*&4", "---2hg", "{}{<>?", "      ", "ABCDEFGH", "abcdefgh", "1234567", "ffff"]:
+        # test without a prefix (shouldn't work)
+        with pytest.raises(ValueError) as ex:
+            assert_is_valid_rams_barcode(s)
+        assert 'barcode validation error' in str(ex.value)
+
+        # test with a prefix (still shouldn't work)
+        with pytest.raises(ValueError) as ex:
+            assert_is_valid_rams_barcode(c.BARCODE_PREFIX_CHAR + s)
         assert 'barcode validation error' in str(ex.value)


### PR DESCRIPTION
- for easier ID'ing strings as barcodes by client code and external apps
- unit tests updated and passed

(was up early and felt like coding something)

ALL TESTED AND READY TO GO!

Generates barcodes with a '~' prefix, like this:

![image](https://user-images.githubusercontent.com/5413064/32609426-b4925d2a-c52d-11e7-879c-e1bfacd9b649.png)

Bonus points: doesn't exactly solve, but works around https://github.com/magfest/ubersystem/issues/2762 because now our barcodes can never start with an ```=``` sign